### PR TITLE
Changing GBC palettes to match the values from GBC Bootstrap ROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ Importing a single palette:
 | grafixkidgreen | Grafixkid Green | ![grafixkidgreen](previews/grafixkidgreen.svg "Palette: grafixkidgreen") | creative |  |
 | blackzero | Game Boy (Black Zero) palette | ![blackzero](previews/blackzero.svg "Palette: blackzero") | creative |  |
 | gbcjp | PocketCamera, JP | ![gbcjp](previews/gbcjp.svg "Palette: gbcjp") | devices, gbcolor |  |
-| gbcu | Game Boy Color Splash Up | ![gbcu](previews/gbcu.svg "Palette: gbcu") | devices, gbcolor | Wikipedia |
-| gbcua | Game Boy Color Splash Up+A | ![gbcua](previews/gbcua.svg "Palette: gbcua") | devices, gbcolor | Wikipedia |
-| gbcub | Game Boy Color Splash Up+B | ![gbcub](previews/gbcub.svg "Palette: gbcub") | devices, gbcolor | Wikipedia |
-| gbcl | Game Boy Color Splash Left | ![gbcl](previews/gbcl.svg "Palette: gbcl") | devices, gbcolor | Wikipedia |
-| gbcla | Game Boy Color Splash Left+A | ![gbcla](previews/gbcla.svg "Palette: gbcla") | devices, gbcolor | Wikipedia |
-| gbclb | Game Boy Color Splash Left+B | ![gbclb](previews/gbclb.svg "Palette: gbclb") | devices, gbcolor | Wikipedia |
-| gbcd | Game Boy Color Splash Down | ![gbcd](previews/gbcd.svg "Palette: gbcd") | devices, gbcolor | Wikipedia |
-| gbcda | Game Boy Color Splash Down+A | ![gbcda](previews/gbcda.svg "Palette: gbcda") | devices, gbcolor | Wikipedia |
-| gbcdb | Game Boy Color Splash Down+B | ![gbcdb](previews/gbcdb.svg "Palette: gbcdb") | devices, gbcolor | Wikipedia |
-| gbcr | Game Boy Color Splash Right | ![gbcr](previews/gbcr.svg "Palette: gbcr") | devices, gbcolor | Wikipedia |
-| gbceuus | Game Boy Color Splash Right+A (Game Boy Camera, EU/US) | ![gbceuus](previews/gbceuus.svg "Palette: gbceuus") | devices, gbcolor | Wikipedia |
-| gbcrb | Game Boy Color Splash Right+B | ![gbcrb](previews/gbcrb.svg "Palette: gbcrb") | devices, gbcolor | Wikipedia |
+| gbcu | Game Boy Color Splash Up | ![gbcu](previews/gbcu.svg "Palette: gbcu") | devices, gbcolor | The Cutting Room Floor |
+| gbcua | Game Boy Color Splash Up+A | ![gbcua](previews/gbcua.svg "Palette: gbcua") | devices, gbcolor | The Cutting Room Floor |
+| gbcub | Game Boy Color Splash Up+B | ![gbcub](previews/gbcub.svg "Palette: gbcub") | devices, gbcolor | The Cutting Room Floor |
+| gbcl | Game Boy Color Splash Left | ![gbcl](previews/gbcl.svg "Palette: gbcl") | devices, gbcolor | The Cutting Room Floor |
+| gbcla | Game Boy Color Splash Left+A | ![gbcla](previews/gbcla.svg "Palette: gbcla") | devices, gbcolor | The Cutting Room Floor |
+| gbclb | Game Boy Color Splash Left+B | ![gbclb](previews/gbclb.svg "Palette: gbclb") | devices, gbcolor | The Cutting Room Floor |
+| gbcd | Game Boy Color Splash Down | ![gbcd](previews/gbcd.svg "Palette: gbcd") | devices, gbcolor | The Cutting Room Floor |
+| gbcda | Game Boy Color Splash Down+A | ![gbcda](previews/gbcda.svg "Palette: gbcda") | devices, gbcolor | The Cutting Room Floor |
+| gbcdb | Game Boy Color Splash Down+B | ![gbcdb](previews/gbcdb.svg "Palette: gbcdb") | devices, gbcolor | The Cutting Room Floor |
+| gbcr | Game Boy Color Splash Right | ![gbcr](previews/gbcr.svg "Palette: gbcr") | devices, gbcolor | The Cutting Room Floor |
+| gbceuus | Game Boy Color Splash Right+A (Game Boy Camera, EU/US) | ![gbceuus](previews/gbceuus.svg "Palette: gbceuus") | devices, gbcolor | The Cutting Room Floor |
+| gbcrb | Game Boy Color Splash Right+B | ![gbcrb](previews/gbcrb.svg "Palette: gbcrb") | devices, gbcolor | The Cutting Room Floor |
 | cybl | Cyanide Blues | ![cybl](previews/cybl.svg "Palette: cybl") | creative | by HerrZatacke |
 | aqpp | Audi Quattro Pikes Peak | ![aqpp](previews/aqpp.svg "Palette: aqpp") | creative |  |
 | wtfp | Waterfront Plaza | ![wtfp](previews/wtfp.svg "Palette: wtfp") | creative |  |

--- a/previews/gbcd.svg
+++ b/previews/gbcd.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffa5" />
   <rect y="0" x="100" height="50" width="100" fill="#fe9494" />
-  <rect y="0" x="200" height="50" width="100" fill="#9394fe" />
+  <rect y="0" x="200" height="50" width="100" fill="#9494ff" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcd.svg
+++ b/previews/gbcd.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffa5" />
-  <rect y="0" x="100" height="50" width="100" fill="#fe9494" />
+  <rect y="0" x="100" height="50" width="100" fill="#ff9494" />
   <rect y="0" x="200" height="50" width="100" fill="#9494ff" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcda.svg
+++ b/previews/gbcda.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
   <rect y="0" x="100" height="50" width="100" fill="#ffff00" />
-  <rect y="0" x="200" height="50" width="100" fill="#fe0000" />
+  <rect y="0" x="200" height="50" width="100" fill="#ff0000" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcdb.svg
+++ b/previews/gbcdb.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
   <rect y="0" x="100" height="50" width="100" fill="#ffff00" />
-  <rect y="0" x="200" height="50" width="100" fill="#7d4900" />
+  <rect y="0" x="200" height="50" width="100" fill="#7b4a00" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbceuus.svg
+++ b/previews/gbceuus.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
-  <rect y="0" x="100" height="50" width="100" fill="#7bff30" />
-  <rect y="0" x="200" height="50" width="100" fill="#0163c6" />
+  <rect y="0" x="100" height="50" width="100" fill="#7bff31" />
+  <rect y="0" x="200" height="50" width="100" fill="#0063c5" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcl.svg
+++ b/previews/gbcl.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
-  <rect y="0" x="100" height="50" width="100" fill="#65a49b" />
-  <rect y="0" x="200" height="50" width="100" fill="#0000fe" />
+  <rect y="0" x="100" height="50" width="100" fill="#63a5ff" />
+  <rect y="0" x="200" height="50" width="100" fill="#0000ff" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcla.svg
+++ b/previews/gbcla.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
-  <rect y="0" x="100" height="50" width="100" fill="#8b8cde" />
-  <rect y="0" x="200" height="50" width="100" fill="#53528c" />
+  <rect y="0" x="100" height="50" width="100" fill="#8c8cde" />
+  <rect y="0" x="200" height="50" width="100" fill="#52528c" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcr.svg
+++ b/previews/gbcr.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
-  <rect y="0" x="100" height="50" width="100" fill="#51ff00" />
+  <rect y="0" x="100" height="50" width="100" fill="#52ff00" />
   <rect y="0" x="200" height="50" width="100" fill="#ff4200" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcrb.svg
+++ b/previews/gbcrb.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#000000" />
-  <rect y="0" x="100" height="50" width="100" fill="#008486" />
+  <rect y="0" x="100" height="50" width="100" fill="#008484" />
   <rect y="0" x="200" height="50" width="100" fill="#ffde00" />
   <rect y="0" x="300" height="50" width="100" fill="#ffffff" />
 </svg>

--- a/previews/gbcu.svg
+++ b/previews/gbcu.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
   <rect y="0" x="100" height="50" width="100" fill="#ffad63" />
-  <rect y="0" x="200" height="50" width="100" fill="#833100" />
+  <rect y="0" x="200" height="50" width="100" fill="#843100" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcua.svg
+++ b/previews/gbcua.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
   <rect y="0" x="0" height="50" width="100" fill="#ffffff" />
-  <rect y="0" x="100" height="50" width="100" fill="#ff8f84" />
+  <rect y="0" x="100" height="50" width="100" fill="#ff8484" />
   <rect y="0" x="200" height="50" width="100" fill="#943a3a" />
   <rect y="0" x="300" height="50" width="100" fill="#000000" />
 </svg>

--- a/previews/gbcub.svg
+++ b/previews/gbcub.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 50">
-  <rect y="0" x="0" height="50" width="100" fill="#ffe7c5" />
-  <rect y="0" x="100" height="50" width="100" fill="#ce9c85" />
+  <rect y="0" x="0" height="50" width="100" fill="#ffe6c5" />
+  <rect y="0" x="100" height="50" width="100" fill="#ce9c84" />
   <rect y="0" x="200" height="50" width="100" fill="#846b29" />
-  <rect y="0" x="300" height="50" width="100" fill="#5b3109" />
+  <rect y="0" x="300" height="50" width="100" fill="#5a3108" />
 </svg>

--- a/src/palettes/gbcd.js
+++ b/src/palettes/gbcd.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcd',
   name: 'Game Boy Color Splash Down',
-  palette: ['#ffffa5', '#fe9494', '#9494ff', '#000000'],
+  palette: ['#ffffa5', '#ff9494', '#9494ff', '#000000'],
   origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcd.js
+++ b/src/palettes/gbcd.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcd',
   name: 'Game Boy Color Splash Down',
-  palette: ['#ffffa5', '#fe9494', '#9394fe', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffa5', '#fe9494', '#9494ff', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcda.js
+++ b/src/palettes/gbcda.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcda',
   name: 'Game Boy Color Splash Down+A',
-  palette: ['#ffffff', '#ffff00', '#fe0000', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#ffff00', '#ff0000', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcdb.js
+++ b/src/palettes/gbcdb.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcdb',
   name: 'Game Boy Color Splash Down+B',
-  palette: ['#ffffff', '#ffff00', '#7d4900', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#ffff00', '#7b4a00', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbceuus.js
+++ b/src/palettes/gbceuus.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbceuus',
   name: 'Game Boy Color Splash Right+A (Game Boy Camera, EU/US)',
-  palette: ['#ffffff', '#7bff30', '#0163c6', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#7bff31', '#0063c5', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcl.js
+++ b/src/palettes/gbcl.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcl',
   name: 'Game Boy Color Splash Left',
-  palette: ['#ffffff', '#65a49b', '#0000fe', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#63a5ff', '#0000ff', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcla.js
+++ b/src/palettes/gbcla.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcla',
   name: 'Game Boy Color Splash Left+A',
-  palette: ['#ffffff', '#8b8cde', '#53528c', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#8c8cde', '#52528c', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbclb.js
+++ b/src/palettes/gbclb.js
@@ -2,5 +2,5 @@ module.exports = {
   shortName: 'gbclb',
   name: 'Game Boy Color Splash Left+B',
   palette: ['#ffffff', '#a5a5a5', '#525252', '#000000'],
-  origin: 'Wikipedia',
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcr.js
+++ b/src/palettes/gbcr.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcr',
   name: 'Game Boy Color Splash Right',
-  palette: ['#ffffff', '#51ff00', '#ff4200', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#52ff00', '#ff4200', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcrb.js
+++ b/src/palettes/gbcrb.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcrb',
   name: 'Game Boy Color Splash Right+B',
-  palette: ['#000000', '#008486', '#ffde00', '#ffffff'],
-  origin: 'Wikipedia',
+  palette: ['#000000', '#008484', '#ffde00', '#ffffff'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcu.js
+++ b/src/palettes/gbcu.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcu',
   name: 'Game Boy Color Splash Up',
-  palette: ['#ffffff', '#ffad63', '#833100', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#ffad63', '#843100', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcua.js
+++ b/src/palettes/gbcua.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcua',
   name: 'Game Boy Color Splash Up+A',
-  palette: ['#ffffff', '#ff8f84', '#943a3a', '#000000'],
-  origin: 'Wikipedia',
+  palette: ['#ffffff', '#ff8484', '#943a3a', '#000000'],
+  origin: 'The Cutting Room Floor',
 };

--- a/src/palettes/gbcub.js
+++ b/src/palettes/gbcub.js
@@ -1,6 +1,6 @@
 module.exports = {
   shortName: 'gbcub',
   name: 'Game Boy Color Splash Up+B',
-  palette: ['#ffe7c5', '#ce9c85', '#846b29', '#5b3109'],
-  origin: 'Wikipedia',
+  palette: ['#ffe6c5', '#ce9c84', '#846b29', '#5a3108'],
+  origin: 'The Cutting Room Floor',
 };


### PR DESCRIPTION
Very slight changes to make the values match the Game Boy Color's Bootstrap ROM exactly.
The most significant changes are to the **gbcl** and **gbcua** palettes; the rest of them are pretty much imperceptible.
Source: https://tcrf.net/Notes:Game_Boy_Color_Bootstrap_ROM